### PR TITLE
FIX: Add mne-qt-browser to requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ conda search mne --channel conda-forge
 About conda-forge
 =================
 
-[![Powered by NumFOCUS](https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](http://numfocus.org)
+[![Powered by
+NumFOCUS](https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](https://numfocus.org)
 
 conda-forge is a community-led conda channel of installable packages.
 In order to provide high-quality builds, the process has been automated into the

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: mne-base

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -75,6 +75,7 @@ outputs:
         - traits
         - traitsui
         - pyface
+        - mne-qt-browser
 
     test:
       imports:


### PR DESCRIPTION
## Description
This adds mne-qt-browser to the requirements in the conda-forge-recipe of `mne`.
Fixes #57

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.