### PR TITLE
Place Spyder & Prompt shortcuts on Windows desktop; remove Sysinfo shortcut

### DIFF
--- a/recipe/menu/menu.json
+++ b/recipe/menu/menu.json
@@ -43,7 +43,7 @@
     "terminal": true,
     "platforms": {
       "win": {
-        "desktop": true
+        "desktop": false
       },
       "linux": {
         "Categories": [
@@ -71,7 +71,7 @@
           "/K",
           "{{ SCRIPTS_DIR }}\\activate.bat"
         ],
-        "desktop": false
+        "desktop": true
       },
       "linux": {
         "command": [

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   git_rev: main
 
 build:
-  number: 20220219
+  number: 20220221
 
 outputs:
   - name: mne-base


### PR DESCRIPTION
as requested by @GuillaumeFavelier