### PR TITLE
FIX: Use bash on macOS, too

### DIFF
--- a/recipe/menu/menu.json
+++ b/recipe/menu/menu.json
@@ -69,7 +69,7 @@
         "command": [
           "%SystemRoot%\\system32\\cmd.exe",
           "/K",
-          "{{ SCRIPTS_DIR }}\\activate.bat"
+          "{{ MENU_DIR }}\\mne_open_prompt.bat"
         ],
         "desktop": false
       },

--- a/recipe/menu/open_prompt.applescript
+++ b/recipe/menu/open_prompt.applescript
@@ -1,4 +1,4 @@
 tell application "Terminal"
-    do script "source __PREFIX__/bin/activate && echo \"Using Python:\" `which python` && echo \"This is\" `mne --version`"
+    do script "source __PREFIX__/Menu/mne_open_prompt.sh"
     activate
 end tell

--- a/recipe/menu/open_prompt.bat
+++ b/recipe/menu/open_prompt.bat
@@ -1,7 +1,7 @@
 :: This is used to initialize the bash prompt on Windows.
 @ECHO OFF
 
-call {{ SCRIPTS_DIR }}\\activate.bat
+call %SCRIPTS_DIR%\Activate.bat
 FOR /F "tokens=*" %%g IN ('python --version') do (SET PYVER=%%g)
 FOR /F "tokens=*" %%g IN ('python --version') do (SET PYPATH=%%g)
 FOR /F "tokens=*" %%g IN ('mne --version') do (SET MNEVER=%%g)

--- a/recipe/menu/open_prompt.bat
+++ b/recipe/menu/open_prompt.bat
@@ -3,7 +3,7 @@
 
 call %__PREFIX__%\Scripts\Activate.bat
 FOR /F "tokens=*" %%g IN ('python --version') do (SET PYVER=%%g)
-FOR /F "tokens=*" %%g IN ('python --version') do (SET PYPATH=%%g)
+FOR /F "tokens=*" %%g IN ('where python') do (SET PYPATH=%%g)
 FOR /F "tokens=*" %%g IN ('mne --version') do (SET MNEVER=%%g)
 
 ECHO Using %PYVER% from %PYPATH%

--- a/recipe/menu/open_prompt.bat
+++ b/recipe/menu/open_prompt.bat
@@ -1,7 +1,7 @@
 :: This is used to initialize the bash prompt on Windows.
 @ECHO OFF
 
-call %SCRIPTS_DIR%\Activate.bat
+call %__PREFIX__%\Scripts\Activate.bat
 FOR /F "tokens=*" %%g IN ('python --version') do (SET PYVER=%%g)
 FOR /F "tokens=*" %%g IN ('python --version') do (SET PYPATH=%%g)
 FOR /F "tokens=*" %%g IN ('mne --version') do (SET MNEVER=%%g)

--- a/recipe/menu/open_prompt.bat
+++ b/recipe/menu/open_prompt.bat
@@ -1,0 +1,10 @@
+:: This is used to initialize the bash prompt on Windows.
+@ECHO OFF
+
+call {{ SCRIPTS_DIR }}\\activate.bat
+FOR /F "tokens=*" %%g IN ('python --version') do (SET PYVER=%%g)
+FOR /F "tokens=*" %%g IN ('python --version') do (SET PYPATH=%%g)
+FOR /F "tokens=*" %%g IN ('mne --version') do (SET MNEVER=%%g)
+
+ECHO Using %PYVER% from %PYPATH%
+ECHO This is %MNEVER%

--- a/recipe/menu/open_prompt.sh
+++ b/recipe/menu/open_prompt.sh
@@ -2,7 +2,7 @@
 
 # This is used to initialize the bash prompt on macOS and Linux.
 
-if [ -f ~/.bashrc ]; then
+if [[ -f ~/.bashrc ]] && [[ ${OSTYPE} != 'darwin'* ]]; then
     source ~/.bashrc
 fi
 source __PREFIX__/bin/activate

--- a/recipe/menu/open_prompt.sh
+++ b/recipe/menu/open_prompt.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ef
+#!/bin/bash
 
 # This is used to initialize the bash prompt on macOS and Linux.
 

--- a/recipe/menu/open_prompt.sh
+++ b/recipe/menu/open_prompt.sh
@@ -1,8 +1,10 @@
-#!/bin/bash
+#!/bin/bash -ef
 
-# This is used to initialize the bash prompt on Linux.
+# This is used to initialize the bash prompt on macOS and Linux.
 
-. ~/.bashrc
-. __PREFIX__/bin/activate
-echo "Using Python: `which python`"
-echo "This is MNE-Python `mne --version`"
+if [ -f ~/.bashrc ]; then
+    source ~/.bashrc
+fi
+source __PREFIX__/bin/activate
+echo "Using $(python --version) from $(which python)"
+echo "This is $(mne --version)"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: mne-base

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -125,6 +125,7 @@ outputs:
         # Use hash as separator, as PREFIX contains forward slashes!
         - sed "s#__PREFIX__#{{ PREFIX }}#" "{{ RECIPE_DIR }}/menu/open_prompt.applescript" > "{{ PREFIX }}/Menu/mne_open_prompt.applescript"  # for macOS
         - sed "s#__PREFIX__#{{ PREFIX }}#" "{{ RECIPE_DIR }}/menu/open_prompt.sh" > "{{ PREFIX }}/Menu/mne_open_prompt.sh"                    # for Linux
+        - sed "s#__PREFIX__#{{ PREFIX }}#" "{{ RECIPE_DIR }}/menu/open_prompt.bat" > "{{ PREFIX }}/Menu/mne_open_prompt.bat"                  # for Windows
 
         # System info
         - cp "{{ RECIPE_DIR }}/menu/info.icns" "{{ PREFIX }}/Menu/mne_info.icns"
@@ -151,6 +152,7 @@ outputs:
         - test -f ${CONDA_PREFIX}/Menu/mne_sys_info.py
         - test -f ${CONDA_PREFIX}/Menu/mne_open_prompt.applescript
         - test -f ${CONDA_PREFIX}/Menu/mne_open_prompt.sh
+        - test -f ${CONDA_PREFIX}/Menu/mne_open_prompt.bat
         # Check we didn't forget any icons
         - test `ls ${CONDA_PREFIX}/Menu/mne_spyder.*  | wc -l` -eq 3
         - test `ls ${CONDA_PREFIX}/Menu/mne_console.* | wc -l` -eq 3


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] ~~Reset the build number to `0` (if the version changed)~~
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Closes https://github.com/mne-tools/mne-installers/issues/93
Closes https://github.com/mne-tools/mne-installers/issues/101

@hoechenberger any reason you didn't use bash on macOS the same way as Linux? In theory I think this should work. Not totally sure how to test it, though...

I would be great if at least on macOS and linux we could locally build this package and then build an `mne-installers` using our local build of the package.