### PR TITLE
WIP: Add Bash option to Windows

### DIFF
--- a/recipe/menu/menu.json
+++ b/recipe/menu/menu.json
@@ -96,6 +96,24 @@
     }
   },
   {
+    "name": "Bash Prompt (MNE)",
+    "description": "MNE-Python Bash prompt",
+    "icon": "{{ MENU_DIR }}/mne_console.{{ ICON_EXT }}",
+    "activate": true,
+    "terminal": true,
+    "command": ["will be overridden in platforms section"],
+    "platforms": {
+      "win": {
+        "command": [
+          "{{ SCRIPTS_DIR }}\\bash",
+          "--init-file",
+          "{{ MENU_DIR }}/mne_open_prompt.sh"
+        ],
+        "desktop": false
+      }
+    }
+  },
+  {
     "name": "Tutorials (MNE)",
     "description": "MNE-Python online tutorials",
     "icon": "{{ MENU_DIR }}/mne_web.{{ ICON_EXT }}",

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -104,6 +104,7 @@ outputs:
         - python >=3.7
         - mne-base
         - spyder
+        - bash
 
     build:
       noarch: python


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

It would be nice to give Windows users an option to use Bash as their terminal, as `cmd` is a pain. This is probably not correct yet and I have no idea how complete `conda-forge`'s `bash` package is, but this is at least a placeholder to think about it. I'm not sure if this is even the way to say "only add this to Windows" because I'm not sure where the menu.json docs live, we should add a link at the top to tell people where to look for examples/docs...