### PR TITLE
ENH: Add export deps

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: mne-base
@@ -84,6 +84,7 @@ outputs:
         - mne-qt-browser
         - ipywidgets
         - ipyvtklink
+        - edflib-python
 
     test:
       requires:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] ~~Reset the build number to `0` (if the version changed)~~
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

@hoechenberger it seems like we should provide this and `eeglabio` so that users can export (e.g., see https://github.com/mne-tools/mne-bids/issues/1002 where a user didn't have EDFlib-Python). However, there isn't a `eeglabio-feedstock` yet. So I think we should make one, get it merged, and then update this PR to include it. WDYT?