### PR TITLE
Drop Spyder dependency from installer-menus package

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: mne-base
@@ -105,7 +105,6 @@ outputs:
       run:
         - python >=3.7
         - mne-base
-        - spyder
 
     build:
       noarch: python


### PR DESCRIPTION
Spyder seems to be blocking the update of `mne-qt-browser`, which in turn is a dependency of `mne`, causing the `mne` and `mne-base` migration to `osx-arm64` to be on hold … if I understand correctly:

https://conda-forge.org/status/#armosxaddition

So now I'm dropping the Spyder dep from `mne-installer-menus`, I'm not sure why we added it back then … Let's hope it's just an old rusty leftover that we can safely remove!

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
