### PR TITLE
Build mne-base on all platforms

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,12 +12,11 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 2
+  number: 3
 
 outputs:
   - name: mne-base
     build:
-      skip: True  # [not linux]
       noarch: python
       script: python -m pip install --no-deps . -vv
       entry_points:


### PR DESCRIPTION
Otherwise, the non-noarch `mne` build won't pick up the correct mne-base package