### PR TITLE
MAINT: Try latest main and no numba

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -89,11 +89,12 @@ outputs:
         - imageio-ffmpeg >=0.4.1
         - traitlets
         - mne-qt-browser
+        - pyopengl  # [osx]
         - ipywidgets
         - ipyvtklink
         - edflib-python
         - eeglabio
-        - openmeeg >=2.5.5
+        - openmeeg >=2.5.6
 
     test:
       requires:
@@ -101,7 +102,7 @@ outputs:
       imports:
         - mne
       commands:
-        - pip check
+        - pip check  # [not win]
         - mne --version
 
   - name: mne-installer-menus

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,9 @@ source:
   git_rev: main
 
 build:
-  number: 20230410
+  number: 20230503
+
+# TODO: Reenable numba soon!
 
 outputs:
   - name: mne-base
@@ -72,7 +74,7 @@ outputs:
         - xlrd
         - scikit-learn >=0.20.2
         - python-picard
-        - numba
+        # numba
         - vtk >=9.2
         - pyvista >=0.32
         - pyvistaqt >=0.4


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] ~~Reset the build number to `0` (if the version changed)~~
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

I'm removing the `numba` dep since I think it's the last blocker for 3.11. Then I'll try `mne-installers` with 3.11. That way if numba does get a 3.11 version out the door we'll hopefully be ready. Or if it doesn't work, we know we shouldn't bother waiting for `numba` to push out 1.4 installers.