### PR TITLE
ENH: Allow selecting Qt bindings using build selectors

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,8 +8,12 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_:
-        CONFIG: linux_64_
+      linux_64_build_variantpyqt:
+        CONFIG: linux_64_build_variantpyqt
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_build_variantpyside6:
+        CONFIG: linux_64_build_variantpyside6
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
   timeoutInMinutes: 360

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,8 +8,11 @@ jobs:
     vmImage: macOS-12
   strategy:
     matrix:
-      osx_64_:
-        CONFIG: osx_64_
+      osx_64_build_variantpyqt:
+        CONFIG: osx_64_build_variantpyqt
+        UPLOAD_PACKAGES: 'True'
+      osx_64_build_variantpyside6:
+        CONFIG: osx_64_build_variantpyside6
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
   variables: {}

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,5 +1,5 @@
 cdt_name:
-- cos6
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/linux_64_build_variantpyqt.yaml
+++ b/.ci_support/linux_64_build_variantpyqt.yaml
@@ -1,0 +1,12 @@
+build_variant:
+- pyqt
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+target_platform:
+- linux-64

--- a/.ci_support/linux_64_build_variantpyside6.yaml
+++ b/.ci_support/linux_64_build_variantpyside6.yaml
@@ -1,5 +1,7 @@
+build_variant:
+- pyside6
 cdt_name:
-- cos7
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_64_build_variantpyqt.yaml
+++ b/.ci_support/osx_64_build_variantpyqt.yaml
@@ -2,6 +2,8 @@ MACOSX_DEPLOYMENT_TARGET:
 - '10.13'
 MACOSX_SDK_VERSION:
 - '10.13'
+build_variant:
+- pyqt
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_64_build_variantpyside6.yaml
+++ b/.ci_support/osx_64_build_variantpyside6.yaml
@@ -1,0 +1,14 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
+build_variant:
+- pyside6
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+macos_machine:
+- x86_64-apple-darwin13.4.0
+target_platform:
+- osx-64

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,3 @@
+build_variant:
+  - "pyqt"
+  - "pyside6"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,6 +4,13 @@
 {% set pymin = "3.9" %}
 {% set build = 1 %}
 
+# Adapted from https://github.com/conda-forge/vtk-feedstock/blob/main/recipe/meta.yaml
+# PySide6 is lower priority than PyQt5 for backward compat (e.g., with matplotlib,
+# mayavi, etc.) until the ecosystem updates
+{% set build = build + 100 %}  # [build_variant == "pyside6"]
+{% set build = build + 200 %}  # [build_variant == "pyqt"]
+{% set build_string = '{}_py{}h{}_{}'.format(build_variant, CONDA_PY, PKG_HASH, build) %}
+
 package:
   name: {{ name|lower }}
   version: {{ version }}
@@ -58,22 +65,6 @@ outputs:
   - name: mne
     build:
       noarch: python
-    requirements:
-      run:
-        - {{ pin_subpackage('mne-noqt', max_pin="x.x.x.x") }}
-        - pyqt
-    test:
-      imports:
-        - mne
-      commands:
-        - pip check  # [not win]
-        - mne --version
-      requires:
-        - pip
-
-  - name: mne-noqt
-    build:
-      noarch: python
 
     requirements:
       run:
@@ -99,6 +90,8 @@ outputs:
         - pyvistaqt >=0.4
         - statsmodels
         - numexpr
+        - pyqt  # [build_variant == "pyqt"]
+        - pyside6  # [build_variant == "pyside6"]
         - pillow
         - joblib
         - psutil

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,6 +58,22 @@ outputs:
   - name: mne
     build:
       noarch: python
+    requirements:
+      run:
+        - {{ pin_subpackage('mne-noqt', max_pin="x.x.x.x") }}
+        - pyqt
+    test:
+      imports:
+        - mne
+      commands:
+        - pip check  # [not win]
+        - mne --version
+      requires:
+        - pip
+
+  - name: mne-noqt
+    build:
+      noarch: python
 
     requirements:
       run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,7 @@ source:
 
 build:
   number: {{ build }}
+  string: {{ build_string }}
 
 outputs:
   - name: mne-base

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = "1.7.1" %}
 {% set sha256 = "a87bbc998b792532d2c87add8b0f7bbf28a4d8cf5db1bdfb6d6e260791754498" %}
 {% set pymin = "3.9" %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 package:
   name: {{ name|lower }}
@@ -83,7 +83,6 @@ outputs:
         - pyvistaqt >=0.4
         - statsmodels
         - numexpr
-        - pyqt
         - pillow
         - joblib
         - psutil


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] ~~Reset the build number to `0` (if the version changed)~~
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

I'm not convinced we should require `pyqt` in our `mne` base recipe. It seems like people should nowadays choose between installing `pyqt` (Qt5) or `pyside6` (Qt6) when doing `conda install mne`. WDYT @hoechenberger ?