### PR TITLE
BUG: Fix bug with package string

### DIFF
--- a/.ci_support/linux_64_build_variantpyqt.yaml
+++ b/.ci_support/linux_64_build_variantpyqt.yaml
@@ -1,7 +1,7 @@
 build_variant:
 - pyqt
 cdt_name:
-- cos6
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/linux_64_build_variantpyside6.yaml
+++ b/.ci_support/linux_64_build_variantpyside6.yaml
@@ -1,7 +1,7 @@
 build_variant:
 - pyside6
 cdt_name:
-- cos6
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@
 # mayavi, etc.) until the ecosystem updates
 {% set build = build + 100 %}  # [build_variant == "pyside6"]
 {% set build = build + 200 %}  # [build_variant == "pyqt"]
-{% set build_string = '{}_h{}_{}'.format(build_variant, CONDA_PY, PKG_HASH, build) %}
+{% set build_string = '{}_h{}_{}'.format(build_variant, PKG_HASH, build) %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,6 @@
 # mayavi, etc.) until the ecosystem updates
 {% set build = build + 100 %}  # [build_variant == "pyside6"]
 {% set build = build + 200 %}  # [build_variant == "pyqt"]
-{% set build_string = '{}_h{}_{}'.format(build_variant, PKG_HASH, build) %}
 
 package:
   name: {{ name|lower }}
@@ -22,7 +21,7 @@ source:
 
 build:
   number: {{ build }}
-  string: {{ build_string }}
+  string: "{{ build_variant }}_h{{ PKG_HASH }}_{{ build }}"
 
 outputs:
   - name: mne-base
@@ -65,7 +64,7 @@ outputs:
 
   - name: mne
     build:
-      string: {{ build_string }}
+      string: "{{ build_variant }}_h{{ PKG_HASH }}_{{ build }}"
       noarch: python
 
     requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@
 # mayavi, etc.) until the ecosystem updates
 {% set build = build + 100 %}  # [build_variant == "pyside6"]
 {% set build = build + 200 %}  # [build_variant == "pyqt"]
-{% set build_string = '{}_h{}_{}'.format(build_variant, PKG_HASH, build) %}
+{% set build_string = '{}_{}'.format(build_variant, build) %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ source:
 
 build:
   number: {{ build }}
-  string: "{{ build_variant }}_h{{ PKG_HASH }}_{{ build }}"
+  string: "{{ build_variant }}_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ build }}"
 
 outputs:
   - name: mne-base
@@ -64,7 +64,7 @@ outputs:
 
   - name: mne
     build:
-      string: "{{ build_variant }}_h{{ PKG_HASH }}_{{ build }}"
+      string: "{{ build_variant }}_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ build }}"
       noarch: python
 
     requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@
 # mayavi, etc.) until the ecosystem updates
 {% set build = build + 100 %}  # [build_variant == "pyside6"]
 {% set build = build + 200 %}  # [build_variant == "pyqt"]
-{% set build_string = '{}_py{}h{}_{}'.format(build_variant, CONDA_PY, PKG_HASH, build) %}
+{% set build_string = '{}_h{}_{}'.format(build_variant, CONDA_PY, PKG_HASH, build) %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@
 # mayavi, etc.) until the ecosystem updates
 {% set build = build + 100 %}  # [build_variant == "pyside6"]
 {% set build = build + 200 %}  # [build_variant == "pyqt"]
-{% set build_string = '{}_{}'.format(build_variant, build) %}
+{% set build_string = '{}_py{}h{}_{}'.format(build_variant, CONDA_PY, PKG_HASH, build) %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,14 +2,14 @@
 {% set version = "1.7.1" %}
 {% set sha256 = "a87bbc998b792532d2c87add8b0f7bbf28a4d8cf5db1bdfb6d6e260791754498" %}
 {% set pymin = "3.9" %}
-{% set build = 1 %}
+{% set build = 2 %}
 
 # Adapted from https://github.com/conda-forge/vtk-feedstock/blob/main/recipe/meta.yaml
 # PySide6 is lower priority than PyQt5 for backward compat (e.g., with matplotlib,
 # mayavi, etc.) until the ecosystem updates
 {% set build = build + 100 %}  # [build_variant == "pyside6"]
 {% set build = build + 200 %}  # [build_variant == "pyqt"]
-{% set build_string = '{}_py{}h{}_{}'.format(build_variant, CONDA_PY, PKG_HASH, build) %}
+{% set build_string = '{}_h{}_{}'.format(build_variant, PKG_HASH, build) %}
 
 package:
   name: {{ name|lower }}
@@ -28,6 +28,7 @@ outputs:
   - name: mne-base
     build:
       noarch: python
+      string: {{ build_string }}
       script: python -m pip install --no-deps . -vv
       entry_points:
         - mne = mne.commands.utils:main
@@ -65,6 +66,7 @@ outputs:
 
   - name: mne
     build:
+      string: {{ build_string }}
       noarch: python
 
     requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,6 @@ outputs:
   - name: mne-base
     build:
       noarch: python
-      string: {{ build_string }}
       script: python -m pip install --no-deps . -vv
       entry_points:
         - mne = mne.commands.utils:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ source:
 
 build:
   number: {{ build }}
-  string: "{{ build_variant }}_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ build }}"
+  string: "{{ build_variant }}_pyh{{ PKG_HASH }}_{{ build }}"
 
 outputs:
   - name: mne-base
@@ -64,7 +64,7 @@ outputs:
 
   - name: mne
     build:
-      string: "{{ build_variant }}_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ build }}"
+      string: "{{ build_variant }}_pyh{{ PKG_HASH }}_{{ build }}"
       noarch: python
 
     requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ source:
 
 build:
   number: {{ build }}
-  string: "{{ build_variant }}_pyh{{ PKG_HASH }}_{{ build }}"
+  string: "{{ build_variant }}_h{{ PKG_HASH }}_{{ build }}"
 
 outputs:
   - name: mne-base
@@ -64,7 +64,7 @@ outputs:
 
   - name: mne
     build:
-      string: "{{ build_variant }}_pyh{{ PKG_HASH }}_{{ build }}"
+      string: "{{ build_variant }}_h{{ PKG_HASH }}_{{ build }}"
       noarch: python
 
     requirements:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] ~~Reset the build number to `0` (if the version changed)~~
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Looking at:

![image](https://github.com/conda-forge/mne-feedstock/assets/2365790/1b34bb7d-8cd5-4d71-8d84-b7113a969e92)

It's incorrect compared to:

![image](https://github.com/conda-forge/mne-feedstock/assets/2365790/bcce2be8-bc91-4e66-9328-646de279f8f0)

I'm hoping that adding the `string:` to *each* build section fixes this. I'll inspect the Azure outputs before merging to make sure it shows up in the name of the built package this time :facepalm: 